### PR TITLE
Fix slide LaTeX syntax errors to ensure clean compilation

### DIFF
--- a/slides/fairness/slides-calibration.tex
+++ b/slides/fairness/slides-calibration.tex
@@ -8,7 +8,9 @@
 \newcommand{\batilde}{\tilde{\mathbf{a}}}
 \newcommand{\Px}{\mathbb{P}_{x}} % P_x
 \newcommand{\Pxj}{\mathbb{P}_{x_j}} % P_{x_j}
-\newcommand{\indep}{\perp \!\!\! \perp} % independence symbol
+
+% indep is now defined in latex-math / basic-math
+% \newcommand{\indep}{\perp \!\!\! \perp} % independence symbol
 
 \usepackage{multicol}
 

--- a/slides/fairness/slides-fairness.tex
+++ b/slides/fairness/slides-fairness.tex
@@ -8,7 +8,9 @@
 \newcommand{\batilde}{\tilde{\mathbf{a}}}
 \newcommand{\Px}{\mathbb{P}_{x}} % P_x
 \newcommand{\Pxj}{\mathbb{P}_{x_j}} % P_{x_j}
-\newcommand{\indep}{\perp \!\!\! \perp} % independence symbol
+
+% indep is now defined in latex-math / basic-math
+% \newcommand{\indep}{\perp \!\!\! \perp} % independence symbol
 
 \usepackage{multicol}
 

--- a/slides/gaussian-processes/slides-gp-basic-3.tex
+++ b/slides/gaussian-processes/slides-gp-basic-3.tex
@@ -6,7 +6,7 @@
 
 
 \newcommand{\titlefigure}{figure_man/discrete/marginalization-more.png} %not best picture
-\newcommandiscrete{\learninggoals}{
+\newcommand{\learninggoals}{
   \item GPs model distributions over functions 
   \item The marginalization property makes this distribution easily tractable
  % \item GPs are fully specified by mean and covariance function 

--- a/slides/gaussian-processes/slides-gp-bayes-lm-deep-dive.tex
+++ b/slides/gaussian-processes/slides-gp-bayes-lm-deep-dive.tex
@@ -4,7 +4,9 @@
 \input{../../latex-math/basic-ml}
 \input{../../latex-math/ml-gp}
 
-\newcommand{\titlefigure}{figure/bayes_lm/posterior_5_3.pdf} % does not fit
+% Figure figure/bayes_lm/posterior_5_3.pdf was not found, 
+% Changed to prevent compilation error
+\newcommand{\titlefigure}{figure/bayes_lm/posterior_5_2.pdf}
 \newcommand{\learninggoals}{
 \item Know the proof the posterior of bayesian linear model.
 \item Know how to derive the predictive distribution of bayesian linear model.

--- a/slides/imbalanced-learning/slides-imbalanced-learning-cost-sensitive-learning-3.tex
+++ b/slides/imbalanced-learning/slides-imbalanced-learning-cost-sensitive-learning-3.tex
@@ -7,6 +7,9 @@
 %\usepackage{algorithm}
 %\usepackage{algorithmic}
 
+% lowr case c vector used only here, was undefined, not in latex-math
+\newcommand{\cv}{\mathbf{c}}
+
 \usepackage{multicol}
 
 \newcommand{\titlefigure}{figure/cost_matrix}


### PR DESCRIPTION
These are all minor issues / typos aside from [`slides/gaussian-processes/slides-gp-bayes-lm-deep-dive.tex`](slides/gaussian-processes/slides-gp-bayes-lm-deep-dive.tex) where I picked an alternative title figure as the one originally referenced is not present in the repository.